### PR TITLE
Update azure-configuration.mdx

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -24,7 +24,7 @@ You must first set up Vault dynamic provider credentials before you can use Vaul
 [See the setup instructions for Vault dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration).
 
 # Configure Vault Azure Secrets Engine
-Follow the instructions in the Vault documentation for [setting up the Azure secrets engine in your Vault instance](/vault/docs/secrets/azure). You can also do this configuration through Terraform. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/azure).
+Follow the instructions in the Vault documentation for [setting up the Azure secrets engine in your Vault instance](/vault/docs/secrets/azure). You can also do this configuration through Terraform. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/tree/main/vault-backed/azure).
 
 ## Configure Terraform Cloud
 Next, you need to set certain environment variables in your Terraform Cloud workspace to authenticate Terraform Cloud with Azure using Vault-backed dynamic credentials. These variables are in addition to those you previously set while configuring [Vault dynamic provider credentials](#configure-vault-dynamic-provider-credentials). You can add these as workspace variables or as a [variable set](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets).


### PR DESCRIPTION
The link is broken, updated the reference to the correct Github link

### What

On this section, the following link is broken: (https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/azure):
# Configure Vault Azure Secrets Engine
Follow the instructions in the Vault documentation for [setting up the Azure secrets engine in your Vault instance](/vault/docs/secrets/azure). You can also do this configuration through Terraform. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/azure).

I changed the broken link 
https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/azure
with 
https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/tree/main/vault-backed/azure

### Why
I changed the link because the users couldn't access the repository to reference the example terraform configuration

### Screenshots
![Screenshot 2024-03-19 at 11 30 09](https://github.com/dlavric/terraform-docs-common/assets/75247430/64308b0a-85d2-410b-8230-54cc316b9065)
